### PR TITLE
Remove dependency on the `basement` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to the
 * Add missing top-level signatures to library.
 * Name the example application `crypton-socks-example`, and move it being built
   behind Cabal flag `example` (default: false).
+* Export the `FQDN` type synonym, representing fully-qualified domain names. The
+  API assumes that such values comprise only ASCII characters. Domain names that
+  include other Unicode code points should be Punycode encoded.
+* Remove dependency on the `basement` package.
 
 ## 0.6.1
 

--- a/crypton-socks.cabal
+++ b/crypton-socks.cabal
@@ -52,7 +52,6 @@ library
   ghc-options: -Wall
   build-depends:
       base >=3 && <5
-    , basement
     , bytestring
     , cereal >=0.3.1
     , network >=2.6

--- a/package.yaml
+++ b/package.yaml
@@ -41,7 +41,6 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-  - basement
   - cereal >= 0.3.1
   - network >= 2.6
   exposed-modules:

--- a/src/Network/Socks5/Types.hs
+++ b/src/Network/Socks5/Types.hs
@@ -17,16 +17,14 @@ module Network.Socks5.Types
   , SocksReply (..)
   , SocksVersionNotSupported (..)
   , SocksError (..)
+  , FQDN
   ) where
 
-import qualified Basement.String as UTF8
 import           Control.Exception ( Exception )
 import           Data.ByteString ( ByteString )
-import qualified Data.ByteString as B
 import           Data.Data ( Data, Typeable )
 import qualified Data.List as L
 import           Data.Word ( Word8 )
-import           GHC.Exts ( IsList (..) )
 import           Network.Socket ( HostAddress, HostAddress6, PortNumber )
 import           Numeric ( showHex )
 
@@ -79,7 +77,7 @@ instance Show SocksHostAddress where
 
 -- | Converts the specified fully-qualified domain name (FQDN) to a 'String'.
 showFQDN :: FQDN -> String
-showFQDN bs = toList $ fst $ UTF8.fromBytesLenient $ fromList $ B.unpack bs
+showFQDN = show
 
 -- | Converts the specified SOCKS host address to a 'String' in dot-decimal
 -- notation.


### PR DESCRIPTION
See:

* #2 

Also exports the `FQDN` type synonym.

Also improves certain related Haddock documentation.